### PR TITLE
Basic Gutenberg Block

### DIFF
--- a/blocks/list-block.php
+++ b/blocks/list-block.php
@@ -1,0 +1,167 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	die( '-1' );
+}
+
+/**
+ * Indicates if current integration is allowed to load.
+ *
+ * @since 17
+ *
+ * @return bool
+ */
+function vsel_list_block_allow_load() {
+	return function_exists( 'register_block_type' );
+}
+
+/**
+ * Loads an integration.
+ *
+ * @since 17
+ */
+function vsel_list_block_load() {
+	vsel_list_block_hooks();
+}
+
+/**
+ * Integration hooks.
+ *
+ * @since 17
+ */
+function vsel_list_block_hooks() {
+	add_action( 'init', 'vsel_list_block_register_block' );
+	add_action( 'enqueue_block_editor_assets', 'vsel_list_block_enqueue_block_editor_assets' );
+}
+
+/**
+ * Register Very Simple Event List Gutenberg block in the backend.
+ *
+ * @since 17
+ */
+function vsel_list_block_register_block() {
+	wp_register_style(
+		'vsel-blocks-styles',
+		trailingslashit( VSEL_PLUGIN_URL ) . 'css/vsel-blocks.css',
+		array( 'wp-edit-blocks' ),
+		VSEL_VERSION
+	);
+
+	$attributes = array(
+		'shortcodeSettings' => array(
+			'type' => 'string',
+		),
+		'noNewChanges'      => array(
+			'type' => 'boolean',
+		),
+		'executed'          => array(
+			'type' => 'boolean',
+		),
+		'listType'          => array(
+			'type' => 'string',
+		)
+	);
+
+	register_block_type(
+		'vsel/vsel-event-list-block',
+		array(
+			'attributes'      => $attributes,
+			'render_callback' => 'vsel_list_block_get_event_html',
+		)
+	);
+}
+
+/**
+ * Load Very Simple Event List Gutenberg block scripts.
+ *
+ * @since 17
+ */
+function vsel_list_block_enqueue_block_editor_assets() {
+	vsel_css_script();
+	wp_enqueue_style( 'vsel-blocks-styles' );
+	wp_enqueue_script(
+		'vsel-blocks-scripts',
+		trailingslashit( VSEL_PLUGIN_URL ) . 'js/vsel-blocks.js',
+		array( 'wp-blocks', 'wp-i18n', 'wp-element' ),
+		VSEL_VERSION,
+		true
+	);
+
+	$shortcodeSettings = '';
+
+	$i18n = array(
+		'title'             => esc_html__( 'Event List', 'very-simple-event-list' ),
+		'addSettings'       => esc_html__( 'Add Settings', 'very-simple-event-list' ),
+		'shortcodeSettings' => esc_html__( 'Shortcode Settings', 'very-simple-event-list' ),
+		'listType'          => esc_html__( 'List Type', 'very-simple-event-list' ),
+		'example'           => esc_html__( 'Example', 'very-simple-event-list' ),
+		'preview'           => esc_html__( 'Apply Changes', 'very-simple-event-list' ),
+	);
+
+	wp_localize_script(
+		'vsel-blocks-scripts',
+		'vsel_block_editor',
+		array(
+			'wpnonce'           => wp_create_nonce( 'vsel-blocks' ),
+			'shortcodeSettings' => $shortcodeSettings,
+			'listTypes' => array(
+				array(
+					'id' => 'vsel',
+					'label' => 'Upcoming Events (today included)'
+				),
+				array(
+					'id' => 'vsel-future-events',
+					'label' => 'Upcoming Events (today not included)'
+				),
+				array(
+					'id' => 'vsel-current-events',
+					'label' => 'Current Events'
+				),
+				array(
+					'id' => 'vsel-past-events',
+					'label' => 'Past Events (before today)'
+				),
+				array(
+					'id' => 'vsel-all-events',
+					'label' => 'Show All Events'
+				),
+			),
+			'i18n'              => $i18n,
+		)
+	);
+}
+
+/**
+ * Get form HTML to display in a Very Simple Event List Gutenberg block.
+ *
+ * @param array $attr Attributes passed by Very Simple Event List Gutenberg block.
+ *
+ * @since 17
+ *
+ * @return string
+ */
+function vsel_list_block_get_event_html( $attr ) {
+
+	$return = '';
+	$list_type = isset( $attr['listType'] ) ? sanitize_text_field( $attr['listType'] ) : 'vsel';
+
+	$shortcode_settings = isset( $attr['shortcodeSettings'] ) ? $attr['shortcodeSettings'] : '';
+
+	$shortcode_settings = str_replace( array( '[vsel', ']' ), '', $shortcode_settings );
+
+	$return .= do_shortcode( '[' . $list_type . ' ' . $shortcode_settings . ']' );
+
+	return $return;
+}
+
+/**
+ * Checking if is Gutenberg REST API call.
+ *
+ * @since 17
+ *
+ * @return bool True if is Gutenberg REST API call.
+ */
+function vsel_list_block_is_gb_editor() {
+
+	// TODO: Find a better way to check if is GB editor API call.
+	return defined( 'REST_REQUEST' ) && REST_REQUEST && ! empty( $_REQUEST['context'] ) && 'edit' === $_REQUEST['context']; // phpcs:ignore
+}

--- a/js/vsel-blocks.js
+++ b/js/vsel-blocks.js
@@ -1,0 +1,127 @@
+"use strict";
+
+(function () {
+	var _wp = wp,
+		_wp$serverSideRender = _wp.serverSideRender,
+		createElement = wp.element.createElement,
+		ServerSideRender = _wp$serverSideRender === void 0 ? wp.components.ServerSideRender : _wp$serverSideRender,
+		_ref = wp.blockEditor || wp.editor,
+		InspectorControls = _ref.InspectorControls,
+		_wp$components = wp.components,
+		TextareaControl = _wp$components.TextareaControl,
+		Button = _wp$components.Button,
+		PanelBody = _wp$components.PanelBody,
+		Placeholder = _wp$components.Placeholder,
+		SelectControl = _wp$components.SelectControl,
+		registerBlockType = wp.blocks.registerBlockType;
+
+	registerBlockType('vsel/vsel-event-list-block', {
+		title: vsel_block_editor.i18n.title,
+		icon: 'calendar',
+		category: 'widgets',
+		attributes: {
+			noNewChanges: {
+				type: 'boolean',
+			},
+			shortcodeSettings: {
+				type: 'string',
+			},
+			executed: {
+				type: 'boolean'
+			},
+			listType: {
+				type: 'string',
+			}
+		},
+		edit: function edit(props) {
+			var _props = props,
+				setAttributes = _props.setAttributes,
+				_props$attributes = _props.attributes,
+				_props$attributes$sho = _props$attributes.shortcodeSettings,
+				shortcodeSettings = _props$attributes$sho === void 0 ? vsel_block_editor.shortcodeSettings : _props$attributes$sho,
+				_props$attributes$cli = _props$attributes.noNewChanges,
+				noNewChanges = _props$attributes$cli === void 0 ? true : _props$attributes$cli,
+				_props$attributes$exe = _props$attributes.executed,
+				executed = _props$attributes$exe === void 0 ? false : _props$attributes$exe,
+				_props$attributes$eve= _props$attributes.listType,
+				listType = _props$attributes$eve === void 0 ? 0 : _props$attributes$eve,
+				listOptions = vsel_block_editor.listTypes.map( value => (
+					{ value: value.id, label: value.label }
+				) );
+
+			function setState(shortcodeSettingsContent) {
+				setAttributes({
+					noNewChanges: false,
+					shortcodeSettings: shortcodeSettingsContent
+				});
+			}
+
+			function selectType( value ) {
+				setAttributes( { listType: value } );
+			}
+
+			function previewClick(content) {
+				setAttributes({
+					noNewChanges: true,
+					executed: false,
+				});
+			}
+
+			function afterRender() {
+				setAttributes({
+					executed: true,
+				});
+			}
+
+			var jsx;
+
+				jsx = [React.createElement(InspectorControls, {
+					key: "vsel-gutenberg-setting-selector-inspector-controls"
+				}, React.createElement(PanelBody, {
+					title: vsel_block_editor.i18n.addSettings
+				},React.createElement(SelectControl, {
+					label: vsel_block_editor.i18n.listType,
+					value: listType,
+					options: listOptions,
+					onChange: selectType
+				}),React.createElement(TextareaControl, {
+					key: "vsel-gutenberg-settings",
+					className: "vsel-gutenberg-settings",
+					label: vsel_block_editor.i18n.shortcodeSettings,
+					help: vsel_block_editor.i18n.example + ": 'posts_per_page=\"5\" pagination=\"false\"'",
+					value: shortcodeSettings,
+					onChange: setState
+				}), React.createElement(Button, {
+					key: "vsel-gutenberg-preview",
+					className: "vsel-gutenberg-preview",
+					onClick: previewClick,
+					isDefault: true
+				}, vsel_block_editor.i18n.preview)))];
+
+				if (noNewChanges) {
+					afterRender();
+					jsx.push(React.createElement(ServerSideRender, {
+						key: "vsel-event-list/vsel-event-list",
+						block: "vsel/vsel-event-list-block",
+						attributes: props.attributes,
+					}));
+				} else {
+					props.attributes.noNewChanges = false;
+					jsx.push(React.createElement(Placeholder, {
+						key: "vsel-gutenberg-setting-selector-select-wrap",
+						className: "vsel-gutenberg-setting-selector-select-wrap"
+					}, React.createElement(Button, {
+						key: "vsel-gutenberg-preview",
+						className: "vsel-gutenberg-preview",
+						onClick: previewClick,
+						isDefault: true
+					}, vsel_block_editor.i18n.preview)));
+				}
+
+			return jsx;
+		},
+		save: function save() {
+			return null;
+		}
+	});
+})();

--- a/vsel.php
+++ b/vsel.php
@@ -689,3 +689,23 @@ include 'vsel-feed.php';
 include 'vsel-page-shortcodes.php';
 include 'vsel-widget-shortcodes.php';
 include 'vsel-template-support.php';
+
+
+// Plugin Folder Path.
+if ( ! defined( 'VSEL_PLUGIN_DIR' ) ) {
+	define( 'VSEL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+// Plugin Folder Path.
+if ( ! defined( 'VSEL_PLUGIN_URL' ) ) {
+	define( 'VSEL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+}
+
+if ( ! defined( 'VSEL_VERSION' ) ) {
+	define( 'VSEL_VERSION', '16.6' );
+}
+
+include_once trailingslashit(VSEL_PLUGIN_DIR ) . 'blocks/list-block.php';
+
+if ( vsel_list_block_allow_load() ) {
+    vsel_list_block_load();
+}


### PR DESCRIPTION
Adds support for a basic Gutenberg block capable of outputting the same content as the various shortcodes in the project. closes #1 